### PR TITLE
Order Endpoint Bug Fix

### DIFF
--- a/Source/Walmart.Sdk.Base/Http/Request.cs
+++ b/Source/Walmart.Sdk.Base/Http/Request.cs
@@ -16,6 +16,7 @@ limitations under the License.
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -64,6 +65,14 @@ namespace Walmart.Sdk.Base.Http
         public void AddPayload(string payload)
         {
             HttpRequest.Content = new StringContent((string)payload, Encoding.UTF8, GetContentType());
+        }
+
+        public void AddPayload(Stream stream)
+        {
+            using (var reader = new StreamReader(stream))
+            {
+                HttpRequest.Content = new StringContent(reader.ReadToEnd(), Encoding.UTF8, GetContentType());
+            }
         }
 
         public string BuildQueryParams()

--- a/Source/Walmart.Sdk.Marketplace/V3/Api/OrderEndpoint.cs
+++ b/Source/Walmart.Sdk.Marketplace/V3/Api/OrderEndpoint.cs
@@ -112,12 +112,14 @@ namespace Walmart.Sdk.Marketplace.V3.Api
         {
             // to avoid deadlock if this method is executed synchronously
             await new ContextRemover();
+            var request = CreateRequest();
 
             string action = "";
             switch (desiredAction)
             {
                 case OrderAction.Ack:
                     action = "acknowledge";
+                    request.AddPayload(string.Empty);
                     break;
                 case OrderAction.Cancel:
                     action = "cancel";
@@ -131,7 +133,7 @@ namespace Walmart.Sdk.Marketplace.V3.Api
                 default:
                     throw new Base.Exception.InvalidValueException("Unknown order action provided >" + action.ToString() + "<");
             }
-            var request = CreateRequest();
+            
             if (stream != null)
             {
                 request.AddMultipartContent(stream);

--- a/Source/Walmart.Sdk.Marketplace/V3/Api/OrderEndpoint.cs
+++ b/Source/Walmart.Sdk.Marketplace/V3/Api/OrderEndpoint.cs
@@ -136,7 +136,7 @@ namespace Walmart.Sdk.Marketplace.V3.Api
             
             if (stream != null)
             {
-                request.AddMultipartContent(stream);
+                request.AddPayload(stream);
             }
             request.EndpointUri = String.Format("/v3/orders/{0}/{1}", purchaseOrderId, action);
             var response = await client.PostAsync(request);
@@ -158,7 +158,7 @@ namespace Walmart.Sdk.Marketplace.V3.Api
             // to avoid deadlock if this method is executed synchronously
             await new ContextRemover();
 
-            var response = await UpdateOrder(purchaseOrderId, OrderAction.Cancel);
+            var response = await UpdateOrder(purchaseOrderId, OrderAction.Cancel, stream);
             var result = await ProcessResponse<Order>(response);
             return result;
         }
@@ -168,7 +168,7 @@ namespace Walmart.Sdk.Marketplace.V3.Api
             // to avoid deadlock if this method is executed synchronously
             await new ContextRemover();
 
-            var response = await UpdateOrder(purchaseOrderId, OrderAction.Refund);
+            var response = await UpdateOrder(purchaseOrderId, OrderAction.Refund, stream);
             var result = await ProcessResponse<Order>(response);
             return result;
         }
@@ -178,7 +178,7 @@ namespace Walmart.Sdk.Marketplace.V3.Api
             // to avoid deadlock if this method is executed synchronously
             await new ContextRemover();
 
-            var response = await UpdateOrder(purchaseOrderId, OrderAction.Shipping);
+            var response = await UpdateOrder(purchaseOrderId, OrderAction.Shipping, stream);
             var result = await ProcessResponse<Order>(response);
             return result;
         }


### PR DESCRIPTION
As per the documentation, order acknowledge requires a "Content-type" header in order to function properly. Otherwise, it throws Internal server errors 500/520 with no indication as to what the issue is; using  AddPayload() solves that issue.

Shipping, canceling, and refunding were all broken. None were actually passing the filestream to UpdateOrder().Adding the stream and using AddPayload() solves the issue and any Internal Server Errors by including the correct "Content-type" header.